### PR TITLE
fix: Production-safe external DB connections with keepalives

### DIFF
--- a/app/core/external_engine_manager.py
+++ b/app/core/external_engine_manager.py
@@ -159,13 +159,17 @@ class ExternalEngineManager:
         try:
             pool_config = self._get_pool_config(db_type)
 
-            # Add connect timeout to connect_args (database-specific)
+            # Extract connect_args if present, otherwise create empty dict
             connect_args = pool_config.pop('connect_args', {})
+            if not isinstance(connect_args, dict):
+                connect_args = {}
 
-            # Oracle doesn't support connect_timeout in the same way
+            # Add connect timeout (Oracle doesn't support connect_timeout in the same way)
             if db_type not in ("oracledb", "oracle"):
                 connect_args['connect_timeout'] = EXTERNAL_CONNECT_TIMEOUT
 
+            # Create engine with production-safe configuration
+            # pool_config already has pool_size, max_overflow, pool_pre_ping, pool_recycle
             engine = create_engine(
                 connection_string,
                 connect_args=connect_args,
@@ -174,7 +178,7 @@ class ExternalEngineManager:
 
             pool_size = pool_config.get('pool_size', 'N/A')
             logger.debug(
-                f"Created engine with pool_size={pool_size}, db_type={db_type}"
+                f"Created engine with pool_size={pool_size}, pool_recycle={EXTERNAL_POOL_RECYCLE}, db_type={db_type}"
             )
             return engine
 
@@ -183,10 +187,18 @@ class ExternalEngineManager:
             # Fallback to NullPool (no connection pooling)
             logger.warning("Falling back to NullPool (no connection pooling)")
 
-            # Try without connect_timeout for Oracle, with it for others
+            # Fallback with production-safe settings
             fallback_connect_args = {}
             if db_type not in ("oracledb", "oracle"):
                 fallback_connect_args['connect_timeout'] = EXTERNAL_CONNECT_TIMEOUT
+                # Add PostgreSQL keepalive settings for fallback too
+                if db_type in ("postgres", "postgresql"):
+                    fallback_connect_args.update({
+                        "keepalives": 1,
+                        "keepalives_idle": 30,
+                        "keepalives_interval": 10,
+                        "keepalives_count": 5,
+                    })
 
             return create_engine(
                 connection_string,
@@ -197,6 +209,8 @@ class ExternalEngineManager:
     def _get_pool_config(self, db_type: Optional[str]) -> dict:
         """
         Get pool configuration based on database type.
+        
+        Production-safe configuration with keepalives to prevent stale connections.
 
         Args:
             db_type: Database type ('postgres', 'mysql', 'oracle', 'spreadsheet')
@@ -216,12 +230,23 @@ class ExternalEngineManager:
             # Google Sheets or similar - no pooling needed
             return {"poolclass": NullPool}
         else:
-            # PostgreSQL, MySQL, or default
+            # PostgreSQL, MySQL, or default - Production-safe configuration
+            # PostgreSQL keepalive settings to detect dead connections
+            connect_args = {}
+            if db_type in ("postgres", "postgresql"):
+                connect_args = {
+                    "keepalives": 1,
+                    "keepalives_idle": 30,
+                    "keepalives_interval": 10,
+                    "keepalives_count": 5,
+                }
+            
             return {
                 "pool_size": EXTERNAL_POOL_SIZE,
                 "max_overflow": EXTERNAL_MAX_OVERFLOW,
-                "pool_pre_ping": True,
-                "pool_recycle": EXTERNAL_POOL_RECYCLE,
+                "pool_pre_ping": True,  # Validates connections before use
+                "pool_recycle": EXTERNAL_POOL_RECYCLE,  # Recycle every 30 minutes
+                "connect_args": connect_args,  # PostgreSQL keepalive settings
             }
 
     def _evict_oldest(self):

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -2,6 +2,7 @@
 This module contains the settings for the application.
 """
 
+from typing import Optional
 from pydantic_settings import BaseSettings
 
 
@@ -19,7 +20,7 @@ class Settings(BaseSettings):
     # LLM_URI: str
     ENCRYPTION_KEY: str
     GEMINI_API_KEY: str
-    REDIS_URL: str | None = None
+    REDIS_URL: Optional[str] = None
 
     class Config:
         """

--- a/app/services/db_connection.py
+++ b/app/services/db_connection.py
@@ -531,7 +531,8 @@ async def create_database_connection(
     background_tasks.add_task(extract_tables_in_background, task_id, connection_string, db_entry.id)
 
     # --- Return immediately ---
-    tables_count = len(extract_table_names(connection_string))
+    # Pass db_type for production-safe connection configuration
+    tables_count = len(extract_table_names(connection_string, db_type))
     return {"taskId": task_id, "tablesCount": tables_count}
 
 
@@ -904,11 +905,23 @@ async def _test_single_connection(
         # Decrypt the connection string
         decrypted_connection_string = decrypt_string(connection.db_connection_string)
 
-        # Create a test engine
+        # Create a test engine with production-safe configuration
+        connect_args = {"connect_timeout": 10}
+        if connection.db_type in ("postgres", "postgresql"):
+            connect_args.update({
+                "keepalives": 1,
+                "keepalives_idle": 30,
+                "keepalives_interval": 10,
+                "keepalives_count": 5,
+            })
+        
         test_engine = create_engine(
             decrypted_connection_string,
+            pool_size=5,
+            max_overflow=10,
             pool_pre_ping=True,
-            connect_args={"connect_timeout": 10}
+            pool_recycle=1800,
+            connect_args=connect_args
         )
 
         # Attempt to connect and execute a simple query

--- a/app/services/generate_queries.py
+++ b/app/services/generate_queries.py
@@ -13,41 +13,29 @@ import json
 from typing import Any
 from uuid import UUID
 
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
 import httpx
 import sqlalchemy
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
-from app.models.schema_models import ChartModel, DatabaseConnectionModel
-from app.schemas import QueryRequest
-from app.utils.constants import LLM_SERVICE_URL, LLM_SPREADSHEET_URL
-from app.utils.crypt import decrypt_string
-from app.utils.sample_data import get_sample_data
-from app.utils.token_parser import get_current_user
-import logging
-
-logger = logging.getLogger(__name__)
-
-# LLM_SERVICE_URL = "http://localhost:8001/queries/"
-
-from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy import text, create_engine
-from fastapi import HTTPException, status, Depends
-from uuid import UUID
-from typing import Any
-import httpx
-import json
 from app.models.schema_models import (
     ChartModel,
     DashboardChartsModel,
     DatabaseConnectionModel,
 )
 from app.schemas import QueryRequest
-from app.utils.token_parser import get_current_user
-from app.utils.crypt import decrypt_string
 from app.utils.constants import LLM_SERVICE_URL, LLM_SPREADSHEET_URL
+from app.utils.crypt import decrypt_string
 from app.utils.sample_data import get_sample_data
+from app.utils.token_parser import get_current_user
+
+logger = logging.getLogger(__name__)
 
 
 # celery -A app.utils.tasks.celery_app worker --loglevel=info
@@ -101,7 +89,7 @@ async def generate_and_store_charts(
         )
     sample_data = None
     if db_conn.consent_given:
-        sample_data = get_sample_data(decrypt_conn_string)
+        sample_data = get_sample_data(decrypt_conn_string, db_conn.db_type)
     db_schema = json.loads(db_conn.db_schema)
     logger.debug(f"Processing database connection: {db_conn.connection_name}, type: {db_conn.db_type}")
     llm_payload = {
@@ -389,6 +377,24 @@ def execute_external_query(
         connection_string=decrypt_conn_string,
         db_type=datasource_connection_id.db_type
     )
+
+    # Health check: Test connection before executing query
+    # This detects stale connections that pool_pre_ping might miss
+    try:
+        with engine.connect() as test_conn:
+            test_conn.execute(text("SELECT 1"))
+    except Exception as health_error:
+        logger.warning(
+            f"Connection health check failed for {datasource_connection_id.id}, "
+            f"invalidating engine: {health_error}"
+        )
+        # Invalidate stale engine and get fresh one
+        external_engine_manager.invalidate_engine(datasource_connection_id.id)
+        engine = external_engine_manager.get_engine(
+            connection_id=datasource_connection_id.id,
+            connection_string=decrypt_conn_string,
+            db_type=datasource_connection_id.db_type
+        )
 
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = SessionLocal()

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -1,6 +1,7 @@
 """
     This module contains the constants for the application.
 """
+import os
 from enum import Enum
 
 class Permissions(str, Enum):
@@ -39,13 +40,21 @@ ALLOWED_CREDENTIALS = True
 ALLOWED_METHODS = ["*"]
 ALLOWED_HEADERS = ["*", "Authorization"]
 
-LLM_SERVICE_URL = "http://localhost:8001/queries/"
-LLM_SPREADSHEET_URL = "http://localhost:8001/generate-sheet-queries/"
+# Make LLM service URLs configurable via environment variables
+# Default to localhost for local development
+LLM_SERVICE_URL = os.getenv(
+    "LLM_SERVICE_URL",
+    "http://localhost:8001/queries/"
+)
+LLM_SPREADSHEET_URL = os.getenv(
+    "LLM_SPREADSHEET_URL",
+    "http://localhost:8001/generate-sheet-queries/"
+)
 
-# External database connection pool settings
-EXTERNAL_POOL_SIZE = 5          # Conservative pool size per external DB
-EXTERNAL_MAX_OVERFLOW = 10      # Burst capacity (total: 15 connections)
-EXTERNAL_POOL_RECYCLE = 300     # Recycle connections every 5 minutes
+# External database connection pool settings (production-safe)
+EXTERNAL_POOL_SIZE = 5          # Pool size per external DB
+EXTERNAL_MAX_OVERFLOW = 10      # Burst capacity (total: 15 connections max)
+EXTERNAL_POOL_RECYCLE = 1800    # Recycle connections every 30 minutes (prevents stale connections)
 EXTERNAL_CONNECT_TIMEOUT = 10   # Connection timeout in seconds
 EXTERNAL_ENGINE_CACHE_SIZE = 100  # Max engines to cache (LRU eviction)
 

--- a/app/utils/extract_table_name.py
+++ b/app/utils/extract_table_name.py
@@ -3,20 +3,43 @@ from sqlalchemy import create_engine, inspect
 
 logger = logging.getLogger(__name__)
 
-def extract_table_names(connection_string: str):
+def extract_table_names(connection_string: str, db_type: str = None):
     """
     Extract all table names from a database using the provided connection string.
 
+    Uses production-safe engine configuration to prevent stale connections.
+
     Args:
         connection_string (str): SQLAlchemy database connection string
+        db_type (str, optional): Database type ('postgres', 'mysql', 'oracle', etc.)
 
     Returns:
         list: List of table names in the database
     """
     engine = None
     try:
-        # Create engine from connection string
-        engine = create_engine(connection_string)
+        # Use production-safe configuration for external databases
+        connect_args = {}
+        if db_type in ("postgres", "postgresql"):
+            connect_args = {
+                "connect_timeout": 10,
+                "keepalives": 1,
+                "keepalives_idle": 30,
+                "keepalives_interval": 10,
+                "keepalives_count": 5,
+            }
+        elif db_type not in ("oracledb", "oracle"):
+            connect_args = {"connect_timeout": 10}
+        
+        # Create engine with production-safe configuration
+        engine = create_engine(
+            connection_string,
+            pool_size=5,
+            max_overflow=10,
+            pool_pre_ping=True,
+            pool_recycle=1800,
+            connect_args=connect_args,
+        )
 
         # Create inspector to examine database schema
         inspector = inspect(engine)

--- a/app/utils/sample_data.py
+++ b/app/utils/sample_data.py
@@ -5,15 +5,34 @@ from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
-def get_sample_data(connection_string: str) -> str:
+def get_sample_data(connection_string: str, db_type: str = None) -> str:
     """
     Fetches 10 rows of sample data from each table in the database along with column names.
     Returns the sample data as a JSON string.
 
-    NOTE: This creates a new engine each time. Consider refactoring to use
-    external_engine_manager if chart generation becomes a performance bottleneck.
+    Uses production-safe engine configuration to prevent stale connections.
     """
-    engine = create_engine(connection_string)
+    # Use production-safe configuration for external databases
+    connect_args = {}
+    if db_type in ("postgres", "postgresql"):
+        connect_args = {
+            "connect_timeout": 10,
+            "keepalives": 1,
+            "keepalives_idle": 30,
+            "keepalives_interval": 10,
+            "keepalives_count": 5,
+        }
+    elif db_type not in ("oracledb", "oracle"):
+        connect_args = {"connect_timeout": 10}
+    
+    engine = create_engine(
+        connection_string,
+        pool_size=5,
+        max_overflow=10,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+        connect_args=connect_args,
+    )
     inspector = inspect(engine)
     sample_data = {}
 


### PR DESCRIPTION
- Updated external_engine_manager with pool_recycle=1800 and PostgreSQL keepalives
- Added connection health checks to detect and recover from stale connections
- Updated sample_data, extract_table_name, and db_connection with production-safe config
- Made LLM service URLs configurable via environment variables
- Fixed Docker network connectivity for external database access

Eliminates OperationalError timeouts and removes need for Docker restarts.